### PR TITLE
Use `main-color` when hovering social links

### DIFF
--- a/github-blog-dark.user.css
+++ b/github-blog-dark.user.css
@@ -294,7 +294,7 @@
     background-color: var(--bg-color-1);
     opacity: .7;
   }
-  .social-links__text:hover {
+  .post__social-share .social-links__text:hover {
     color: var(--main-color);
   }
   /* category img fixes protect retinas, enabled */

--- a/github-blog-dark.user.css
+++ b/github-blog-dark.user.css
@@ -294,6 +294,9 @@
     background-color: var(--bg-color-1);
     opacity: .7;
   }
+  .social-links__text:hover {
+    color: var(--main-color);
+  }
   /* category img fixes protect retinas, enabled */
   img[src*="BlogHeaders_Aligned_ENGINEERING_1008x602_x2.png"],
   img[src*="BlogHeaders_Aligned_CHANGELOG_1008x602_x2.png"],


### PR DESCRIPTION
When hovering on article social links, the colour is blue, not the main colour set by the user:

<img width="1312" alt="Screenshot 2020-04-13 at 16 50 24" src="https://user-images.githubusercontent.com/62398724/79135432-3925a400-7da7-11ea-9b84-17868476c636.png">

This PR aims to fix this